### PR TITLE
Password validator 03-09-24-1

### DIFF
--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -30,28 +30,13 @@ import { PasswordValidator } from ".";
 
 describe('password validator', () => {
 
-  test.skip('hello', () => {
+  it('Should list all the occurring validation errors', () => {
     // arrange
+    const pasword = '';
 
     // act
 
-    const validationResult = {
-      result: false,
-      errors: [
-        {
-          type: 'InvalidLengthError',
-          message: 'Password must be between 5 and 15 characters long.'
-        },
-        {
-          type: 'NoDigitError',
-          message: 'Password must contain at least one digit.'
-        },
-        {
-          type: 'NoUpperCaseCharacterError',
-          message: 'Password must contain at least one upper case letter.'
-        }
-      ]
-    };
+    const validationResult = PasswordValidator.Validate(pasword);
 
     // assert
     expect(validationResult.result).toBe(false);

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -25,6 +25,8 @@ ValidationResponse:
 - holds the list of errors.
 */
 
+import { PasswordValidator } from ".";
+
 
 describe('password validator', () => {
 
@@ -60,6 +62,26 @@ describe('password validator', () => {
     expect(validationResult.errors[1].message).toBe('Password must contain at least one digit.');
     expect(validationResult.errors[2].type).toBe('NoUpperCaseCharacterError');
     expect(validationResult.errors[2].message).toBe('Password must contain at least one upper case letter.');
+  })
+
+  describe('The password must be between 5 and 15 characters long', ()=>{
+
+    test('"thePhysical1234567" returns a false-y response because of exceeding the 15 character length', ()=>{
+      
+      // arrange
+      const password = 'thePhysical1234567';
+
+      // act
+      const validationResult = PasswordValidator.Validate(password);
+
+      // assert
+
+      expect(validationResult.result).toBe(false);
+      expect(validationResult.errors).toHaveLength(1);
+      expect(validationResult.errors[0].type).toBe('InvalidLengthError');
+      expect(validationResult.errors[0].message).toBe('Password must be between 5 and 15 characters long.');
+    })
+
   })
 })
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -81,8 +81,21 @@ describe('password validator', () => {
       expect(validationResult.errors[0].type).toBe('InvalidLengthError');
       expect(validationResult.errors[0].message).toBe('Password must be between 5 and 15 characters long.');
     })
-
   })
+
+  test('"abc" returns a false-y response because of being shorter than 5 characters', () => {
+    // arrange
+    const password = 'abc';
+
+    // act
+    const validationResult = PasswordValidator.Validate(password);
+
+    // assert
+    expect(validationResult.result).toBe(false);
+    expect(validationResult.errors).toHaveLength(1);
+    expect(validationResult.errors[0].type).toBe('InvalidLengthError');
+    expect(validationResult.errors[0].message).toBe('Password must be between 5 and 15 characters long.');
+  });
 })
 
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -69,8 +69,8 @@ describe('password validator', () => {
     // Parameterized tests for invalid length cases
     test.each([
       'thePhysical1234567',  // exceeds 15 characters
-      'abcd',                 // exactly 4 characters (pne below the limit)
-      'abcdefghijklmnop'     // exactly 16 characters (one over the limit)
+      'abc1',                 // exactly 4 characters (pne below the limit)
+      'abcdefghijklmno1'     // exactly 16 characters (one over the limit)
     ])('"%s" returns a false-y response due to invalid length', (password) => {
 
       // act
@@ -85,7 +85,7 @@ describe('password validator', () => {
 
     // Parameterized test for valid length case
     test.each([
-      'abcde',               // exactly 5 characters (valid edge case)
+      'abcd1',               // exactly 5 characters (valid edge case)
       'abcdefghij12345',     // exactly 15 characters (valid edge case)
       'theValid1',  // within the valid length range
     ])('"%s" returns a truthy response because it is within the valid length range', (password) => {
@@ -98,6 +98,24 @@ describe('password validator', () => {
       expect(validationResult.errors).toHaveLength(0);
     });
 
+  });
+
+  describe('Password must contain at least one digit', () => {
+
+    test('"noDigitPassword" returns a false-y response because it lacks a digit', () => {
+      // arrange
+      const password = 'noDigitPassword';
+  
+      // act
+      const validationResult = PasswordValidator.Validate(password);
+  
+      // assert
+      expect(validationResult.result).toBe(false);
+      expect(validationResult.errors).toHaveLength(1);
+      expect(validationResult.errors[0].type).toBe('NoDigitError');
+      expect(validationResult.errors[0].message).toBe('Password must contain at least one digit.');
+    });
+  
   });
 })
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -16,13 +16,11 @@ function expectToFail(validationResult: ValidationResult, ...errors: ValidationE
 describe('password validator', () => {
 
   it('Should list all the occurring validation errors', () => {
-    // arrange
+
     const password = '';
 
-    // act
     const validationResult = PasswordValidator.Validate(password);
 
-    // assert
     expectToFail(validationResult,
       { type: ValidationErrorType.InvalidLengthError, message: 'Password must be between 5 and 15 characters long.' },
       { type: ValidationErrorType.NoDigitError, message: 'Password must contain at least one digit.' },
@@ -38,10 +36,9 @@ describe('password validator', () => {
       'Abc1',                 // exactly 4 characters (one below the limit)
       'Abcdefghijklmno1'     // exactly 16 characters (one over the limit)
     ])('"%s" returns a false-y response due to invalid length', (password) => {
-      // act
+
       const validationResult = PasswordValidator.Validate(password);
 
-      // assert
       expectToFail(validationResult,
         { type: ValidationErrorType.InvalidLengthError, message: 'Password must be between 5 and 15 characters long.' }
       );
@@ -53,10 +50,9 @@ describe('password validator', () => {
       'Abcdefghij12345',     // exactly 15 characters (valid edge case)
       'theValid1',           // within the valid length range
     ])('"%s" returns a truthy response because it is within the valid length range', (password) => {
-      // act
+
       const validationResult = PasswordValidator.Validate(password);
 
-      // assert
       expectToPass(validationResult);
     });
 
@@ -65,26 +61,22 @@ describe('password validator', () => {
   describe('Password must contain at least one digit', () => {
 
     test('"maxwellTheBe" returns a false-y response because it lacks a digit', () => {
-      // arrange
+
       const password = 'maxwellTheBe';
 
-      // act
       const validationResult = PasswordValidator.Validate(password);
 
-      // assert
       expectToFail(validationResult,
         { type: ValidationErrorType.NoDigitError, message: 'Password must contain at least one digit.' }
       );
     });
 
     test('"password1" returns a truthy response because it contains a digit', () => {
-      // arrange
+
       const password = 'Password1';
 
-      // act
       const validationResult = PasswordValidator.Validate(password);
 
-      // assert
       expectToPass(validationResult);
     });
 
@@ -93,26 +85,22 @@ describe('password validator', () => {
   describe('Password must contain at least one uppercase letter', () => {
 
     test('"maxwell1_c" returns a false-y response because it lacks an uppercase letter', () => {
-      // arrange
+
       const password = 'maxwell1_c';
 
-      // act
       const validationResult = PasswordValidator.Validate(password);
 
-      // assert
       expectToFail(validationResult,
         { type: ValidationErrorType.NoUpperCaseCharacterError, message: 'Password must contain at least one upper case letter.' }
       );
     });
     
     test('"Password1" returns a truthy response because it contains an uppercase letter', () => {
-      // arrange
+
       const password = 'Password1';
 
-      // act
       const validationResult = PasswordValidator.Validate(password);
 
-      // assert
       expectToPass(validationResult);
     });
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -1,3 +1,30 @@
+/*
+
+COLLABORATORS
+
+- PasswordValidator
+- ValidationResponse
+
+RESPONSIBILITIES
+
+PasswordValidator:
+
+- validates password.
+  - Between 5 and 15 characters long. 
+      Ex.: "thePhysical1234567" returns a false-y response because of exceeding the 15 character length
+  - Contains at least one digit.
+      Ex.: "maxwellTheBe" returns a false-y response because of a lack of digits
+  - Contains at least one upper case letter.
+      Ex.: "maxwell1_c" returns a false-y response because of a lack of uppercase characters
+- constructs ValidationResponse.
+Ex.: "thePhysical1" returns a true response because the password matches all criteria
+
+ValidationResponse:
+
+- holds boolean result of the validation.
+- holds the list of errors.
+*/
+
 
 describe('password validator', () => {
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -145,6 +145,18 @@ describe('password validator', () => {
       expect(validationResult.errors[0].type).toBe('NoUpperCaseCharacterError');
       expect(validationResult.errors[0].message).toBe('Password must contain at least one upper case letter.');
     });
+    
+    test('"Password1" returns a truthy response because it contains an uppercase letter', () => {
+      // arrange
+      const password = 'Password1'; // Contains the uppercase letter 'P'
+  
+      // act
+      const validationResult = PasswordValidator.Validate(password);
+  
+      // assert
+      expect(validationResult.result).toBe(true);
+      expect(validationResult.errors).toHaveLength(0); // No errors expected
+    });
   
   });
 })

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -116,6 +116,18 @@ describe('password validator', () => {
       expect(validationResult.errors[0].message).toBe('Password must contain at least one digit.');
     });
   
+    test('"password1" returns a truthy response because it contains a digit', () => {
+      // arrange
+      const password = 'password1'; // Contains the digit '1'
+  
+      // act
+      const validationResult = PasswordValidator.Validate(password);
+  
+      // assert
+      expect(validationResult.result).toBe(true);
+      expect(validationResult.errors).toHaveLength(0); // No errors expected
+    });
+    
   });
 })
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { PasswordValidator, ValidationResult, ValidationError } from ".";
+import { PasswordValidator, ValidationResult, ValidationError, ValidationErrorType } from ".";
 
 // Utility function for asserting successful validation
 function expectToPass(validationResult: ValidationResult) {
@@ -24,9 +24,9 @@ describe('password validator', () => {
 
     // assert
     expectToFail(validationResult,
-      { type: 'InvalidLengthError', message: 'Password must be between 5 and 15 characters long.' },
-      { type: 'NoDigitError', message: 'Password must contain at least one digit.' },
-      { type: 'NoUpperCaseCharacterError', message: 'Password must contain at least one upper case letter.' }
+      { type: ValidationErrorType.InvalidLengthError, message: 'Password must be between 5 and 15 characters long.' },
+      { type: ValidationErrorType.NoDigitError, message: 'Password must contain at least one digit.' },
+      { type: ValidationErrorType.NoUpperCaseCharacterError, message: 'Password must contain at least one upper case letter.' }
     );
   });
 
@@ -43,7 +43,7 @@ describe('password validator', () => {
 
       // assert
       expectToFail(validationResult,
-        { type: 'InvalidLengthError', message: 'Password must be between 5 and 15 characters long.' }
+        { type: ValidationErrorType.InvalidLengthError, message: 'Password must be between 5 and 15 characters long.' }
       );
     });
 
@@ -73,7 +73,7 @@ describe('password validator', () => {
 
       // assert
       expectToFail(validationResult,
-        { type: 'NoDigitError', message: 'Password must contain at least one digit.' }
+        { type: ValidationErrorType.NoDigitError, message: 'Password must contain at least one digit.' }
       );
     });
 
@@ -101,7 +101,7 @@ describe('password validator', () => {
 
       // assert
       expectToFail(validationResult,
-        { type: 'NoUpperCaseCharacterError', message: 'Password must contain at least one upper case letter.' }
+        { type: ValidationErrorType.NoUpperCaseCharacterError, message: 'Password must contain at least one upper case letter.' }
       );
     });
     

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -28,8 +28,23 @@ ValidationResponse:
 
 describe('password validator', () => {
 
-  test('hello', () => {
-    expect("between 5 and 15").toContain('5 and 15')
+  test.skip('hello', () => {
+    // arrange
+
+    // act
+
+    const validationResult = {
+      result: false,
+      errors: [
+        'InvalidLengthError',
+        'NoDigitError',
+        'NoUppercaseCharacterError'
+      ]
+    };
+
+    // assert
+    expect(validationResult.result).toBe(false);
+    expect(validationResult.errors).toHaveLength(3);
   })
 })
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -1,119 +1,120 @@
-import { PasswordValidator, ValidationResult } from ".";
+import { PasswordValidator, ValidationResult, ValidationError } from ".";
 
 // Utility function for asserting successful validation
 function expectToPass(validationResult: ValidationResult) {
-    expect(validationResult.result).toBe(true);
-    expect(validationResult.errors).toHaveLength(0);
+  expect(validationResult.result).toBe(true);
+  expect(validationResult.errors).toHaveLength(0);
+}
+
+// Utility function for asserting failed validation
+function expectToFail(validationResult: ValidationResult, ...errors: ValidationError[]) {
+  expect(validationResult.result).toBe(false);
+  expect(validationResult.errors).toHaveLength(errors.length);
+  expect(validationResult.errors).toMatchObject(errors);
 }
 
 describe('password validator', () => {
 
-  it('Should list all the occurring validation errors', () => {
+it('Should list all the occurring validation errors', () => {
+  // arrange
+  const password = '';
+
+  // act
+  const validationResult = PasswordValidator.Validate(password);
+
+  // assert
+  expectToFail(validationResult,
+    { type: 'InvalidLengthError', message: 'Password must be between 5 and 15 characters long.' },
+    { type: 'NoDigitError', message: 'Password must contain at least one digit.' },
+    { type: 'NoUpperCaseCharacterError', message: 'Password must contain at least one upper case letter.' }
+  );
+});
+
+describe('The password must be between 5 and 15 characters long', () => {
+
+  // Parameterized tests for invalid length cases
+  test.each([
+    'thePhysical1234567',  // exceeds 15 characters
+    'Abc1',                 // exactly 4 characters (one below the limit)
+    'Abcdefghijklmno1'     // exactly 16 characters (one over the limit)
+  ])('"%s" returns a false-y response due to invalid length', (password) => {
+    // act
+    const validationResult = PasswordValidator.Validate(password);
+
+    // assert
+    expectToFail(validationResult,
+      { type: 'InvalidLengthError', message: 'Password must be between 5 and 15 characters long.' }
+    );
+  });
+
+  // Parameterized test for valid length cases
+  test.each([
+    'Abcd1',               // exactly 5 characters (valid edge case)
+    'Abcdefghij12345',     // exactly 15 characters (valid edge case)
+    'theValid1',           // within the valid length range
+  ])('"%s" returns a truthy response because it is within the valid length range', (password) => {
+    // act
+    const validationResult = PasswordValidator.Validate(password);
+
+    // assert
+    expectToPass(validationResult);
+  });
+
+});
+
+describe('Password must contain at least one digit', () => {
+
+  test('"maxwellTheBe" returns a false-y response because it lacks a digit', () => {
     // arrange
-    const password = '';
+    const password = 'maxwellTheBe';
 
     // act
     const validationResult = PasswordValidator.Validate(password);
 
     // assert
-    expect(validationResult.result).toBe(false);
-    expect(validationResult.errors).toHaveLength(3);
-    expect(validationResult.errors[0].type).toBe('InvalidLengthError');
-    expect(validationResult.errors[0].message).toBe('Password must be between 5 and 15 characters long.');
-    expect(validationResult.errors[1].type).toBe('NoDigitError');
-    expect(validationResult.errors[1].message).toBe('Password must contain at least one digit.');
-    expect(validationResult.errors[2].type).toBe('NoUpperCaseCharacterError');
-    expect(validationResult.errors[2].message).toBe('Password must contain at least one upper case letter.');
+    expectToFail(validationResult,
+      { type: 'NoDigitError', message: 'Password must contain at least one digit.' }
+    );
   });
 
-  describe('The password must be between 5 and 15 characters long', () => {
+  test('"password1" returns a truthy response because it contains a digit', () => {
+    // arrange
+    const password = 'Password1';
 
-    // Parameterized tests for invalid length cases
-    test.each([
-      'thePhysical1234567',  // exceeds 15 characters
-      'Abc1',                 // exactly 4 characters (one below the limit)
-      'Abcdefghijklmno1'     // exactly 16 characters (one over the limit)
-    ])('"%s" returns a false-y response due to invalid length', (password) => {
-      // act
-      const validationResult = PasswordValidator.Validate(password);
+    // act
+    const validationResult = PasswordValidator.Validate(password);
 
-      // assert
-      expect(validationResult.result).toBe(false);
-      expect(validationResult.errors).toHaveLength(1);
-      expect(validationResult.errors[0].type).toBe('InvalidLengthError');
-      expect(validationResult.errors[0].message).toBe('Password must be between 5 and 15 characters long.');
-    });
-
-    // Parameterized test for valid length cases
-    test.each([
-      'Abcd1',               // exactly 5 characters (valid edge case)
-      'Abcdefghij12345',     // exactly 15 characters (valid edge case)
-      'theValid1',  // within the valid length range
-    ])('"%s" returns a truthy response because it is within the valid length range', (password) => {
-      // act
-      const validationResult = PasswordValidator.Validate(password);
-
-      // assert
-      expectToPass(validationResult);
-    });
-
+    // assert
+    expectToPass(validationResult);
   });
 
-  describe('Password must contain at least one digit', () => {
+});
 
-    test('"maxwellTheBe" returns a false-y response because it lacks a digit', () => {
-      // arrange
-      const password = 'maxwellTheBe';
-  
-      // act
-      const validationResult = PasswordValidator.Validate(password);
-  
-      // assert
-      expect(validationResult.result).toBe(false);
-      expect(validationResult.errors).toHaveLength(1);
-      expect(validationResult.errors[0].type).toBe('NoDigitError');
-      expect(validationResult.errors[0].message).toBe('Password must contain at least one digit.');
-    });
-  
-    test('"password1" returns a truthy response because it contains a digit', () => {
-      // arrange
-      const password = 'Password1';
-  
-      // act
-      const validationResult = PasswordValidator.Validate(password);
-  
-      // assert
-      expectToPass(validationResult);
-    });
+describe('Password must contain at least one uppercase letter', () => {
 
+  test('"maxwell1_c" returns a false-y response because it lacks an uppercase letter', () => {
+    // arrange
+    const password = 'maxwell1_c';
+
+    // act
+    const validationResult = PasswordValidator.Validate(password);
+
+    // assert
+    expectToFail(validationResult,
+      { type: 'NoUpperCaseCharacterError', message: 'Password must contain at least one upper case letter.' }
+    );
+  });
+  
+  test('"Password1" returns a truthy response because it contains an uppercase letter', () => {
+    // arrange
+    const password = 'Password1';
+
+    // act
+    const validationResult = PasswordValidator.Validate(password);
+
+    // assert
+    expectToPass(validationResult);
   });
 
-  describe('Password must contain at least one uppercase letter', () => {
-
-    test('"maxwell1_c" returns a false-y response because it lacks an uppercase letter', () => {
-      // arrange
-      const password = 'maxwell1_c';
-  
-      // act
-      const validationResult = PasswordValidator.Validate(password);
-  
-      // assert
-      expect(validationResult.result).toBe(false);
-      expect(validationResult.errors).toHaveLength(1);
-      expect(validationResult.errors[0].type).toBe('NoUpperCaseCharacterError');
-      expect(validationResult.errors[0].message).toBe('Password must contain at least one upper case letter.');
-    });
-    
-    test('"Password1" returns a truthy response because it contains an uppercase letter', () => {
-      // arrange
-      const password = 'Password1';
-  
-      // act
-      const validationResult = PasswordValidator.Validate(password);
-  
-      // assert
-      expectToPass(validationResult);
-    });
-  
-  });
+});
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -36,15 +36,30 @@ describe('password validator', () => {
     const validationResult = {
       result: false,
       errors: [
-        'InvalidLengthError',
-        'NoDigitError',
-        'NoUppercaseCharacterError'
+        {
+          type: 'InvalidLengthError',
+          message: 'Password must be between 5 and 15 characters long.'
+        },
+        {
+          type: 'NoDigitError',
+          message: 'Password must contain at least one digit.'
+        },
+        {
+          type: 'NoUpperCaseCharacterError',
+          message: 'Password must contain at least one upper case letter.'
+        }
       ]
     };
 
     // assert
     expect(validationResult.result).toBe(false);
     expect(validationResult.errors).toHaveLength(3);
+    expect(validationResult.errors[0].type).toBe('InvalidLengthError');
+    expect(validationResult.errors[0].message).toBe('Password must be between 5 and 15 characters long.');
+    expect(validationResult.errors[1].type).toBe('NoDigitError');
+    expect(validationResult.errors[1].message).toBe('Password must contain at least one digit.');
+    expect(validationResult.errors[2].type).toBe('NoUpperCaseCharacterError');
+    expect(validationResult.errors[2].message).toBe('Password must contain at least one upper case letter.');
   })
 })
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -66,47 +66,35 @@ describe('password validator', () => {
 
   describe('The password must be between 5 and 15 characters long', ()=>{
 
-    test('"thePhysical1234567" returns a false-y response because of exceeding the 15 character length', ()=>{
-      
-      // arrange
-      const password = 'thePhysical1234567';
+    // Parameterized tests for invalid length cases
+    test.each([
+      'thePhysical1234567', // exceeds 15 characters
+      'abc',                // less than 5 characters
+    ])('"%s" returns a false-y response due to invalid length', (password) => {
 
       // act
       const validationResult = PasswordValidator.Validate(password);
 
       // assert
-
       expect(validationResult.result).toBe(false);
       expect(validationResult.errors).toHaveLength(1);
       expect(validationResult.errors[0].type).toBe('InvalidLengthError');
       expect(validationResult.errors[0].message).toBe('Password must be between 5 and 15 characters long.');
-    })
-  })
+    });
 
-  test('"abc" returns a false-y response because of being shorter than 5 characters', () => {
-    // arrange
-    const password = 'abc';
+    // Parameterized test for valid length case
+    test.each([
+      'theValid1',  // within the valid length range
+    ])('"%s" returns a truthy response because it is within the valid length range', (password) => {
 
-    // act
-    const validationResult = PasswordValidator.Validate(password);
+      // act
+      const validationResult = PasswordValidator.Validate(password);
 
-    // assert
-    expect(validationResult.result).toBe(false);
-    expect(validationResult.errors).toHaveLength(1);
-    expect(validationResult.errors[0].type).toBe('InvalidLengthError');
-    expect(validationResult.errors[0].message).toBe('Password must be between 5 and 15 characters long.');
-  });
+      // assert
+      expect(validationResult.result).toBe(true);
+      expect(validationResult.errors).toHaveLength(0);
+    });
 
-  test('"theValid1" returns a truthy response because it is within the valid length range', () => {
-    // arrange
-    const password = 'theValid1'; // 9 characters, valid
-
-    // act
-    const validationResult = PasswordValidator.Validate(password);
-
-    // assert
-    expect(validationResult.result).toBe(true);
-    expect(validationResult.errors).toHaveLength(0); // No errors expected
   });
 })
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -132,9 +132,9 @@ describe('password validator', () => {
 
   describe('Password must contain at least one uppercase letter', () => {
 
-    test('"lowercaseonly" returns a false-y response because it lacks an uppercase letter', () => {
+    test('"maxwell1_c" returns a false-y response because it lacks an uppercase letter', () => {
       // arrange
-      const password = 'lowercaseonly1'; // No uppercase letters
+      const password = 'maxwell1_c';
   
       // act
       const validationResult = PasswordValidator.Validate(password);

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -68,8 +68,9 @@ describe('password validator', () => {
 
     // Parameterized tests for invalid length cases
     test.each([
-      'thePhysical1234567', // exceeds 15 characters
-      'abc',                // less than 5 characters
+      'thePhysical1234567',  // exceeds 15 characters
+      'abcd',                 // exactly 4 characters (pne below the limit)
+      'abcdefghijklmnop'     // exactly 16 characters (one over the limit)
     ])('"%s" returns a false-y response due to invalid length', (password) => {
 
       // act
@@ -84,6 +85,8 @@ describe('password validator', () => {
 
     // Parameterized test for valid length case
     test.each([
+      'abcde',               // exactly 5 characters (valid edge case)
+      'abcdefghij12345',     // exactly 15 characters (valid edge case)
       'theValid1',  // within the valid length range
     ])('"%s" returns a truthy response because it is within the valid length range', (password) => {
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -102,9 +102,9 @@ describe('password validator', () => {
 
   describe('Password must contain at least one digit', () => {
 
-    test('"noDigitPassword" returns a false-y response because it lacks a digit', () => {
+    test('"maxwellTheBe" returns a false-y response because it lacks a digit', () => {
       // arrange
-      const password = 'noDigitPassword';
+      const password = 'maxwellTheBe';
   
       // act
       const validationResult = PasswordValidator.Validate(password);
@@ -148,14 +148,14 @@ describe('password validator', () => {
     
     test('"Password1" returns a truthy response because it contains an uppercase letter', () => {
       // arrange
-      const password = 'Password1'; // Contains the uppercase letter 'P'
+      const password = 'Password1';
   
       // act
       const validationResult = PasswordValidator.Validate(password);
   
       // assert
       expect(validationResult.result).toBe(true);
-      expect(validationResult.errors).toHaveLength(0); // No errors expected
+      expect(validationResult.errors).toHaveLength(0);
     });
   
   });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -1,30 +1,3 @@
-/*
-
-COLLABORATORS
-
-- PasswordValidator
-- ValidationResponse
-
-RESPONSIBILITIES
-
-PasswordValidator:
-
-- validates password.
-  - Between 5 and 15 characters long. 
-      Ex.: "thePhysical1234567" returns a false-y response because of exceeding the 15 character length
-  - Contains at least one digit.
-      Ex.: "maxwellTheBe" returns a false-y response because of a lack of digits
-  - Contains at least one upper case letter.
-      Ex.: "maxwell1_c" returns a false-y response because of a lack of uppercase characters
-- constructs ValidationResponse.
-Ex.: "thePhysical1" returns a true response because the password matches all criteria
-
-ValidationResponse:
-
-- holds boolean result of the validation.
-- holds the list of errors.
-*/
-
 import { PasswordValidator } from ".";
 
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -69,8 +69,8 @@ describe('password validator', () => {
     // Parameterized tests for invalid length cases
     test.each([
       'thePhysical1234567',  // exceeds 15 characters
-      'abc1',                 // exactly 4 characters (pne below the limit)
-      'abcdefghijklmno1'     // exactly 16 characters (one over the limit)
+      'Abc1',                 // exactly 4 characters (pne below the limit)
+      'Abcdefghijklmno1'     // exactly 16 characters (one over the limit)
     ])('"%s" returns a false-y response due to invalid length', (password) => {
 
       // act
@@ -85,8 +85,8 @@ describe('password validator', () => {
 
     // Parameterized test for valid length case
     test.each([
-      'abcd1',               // exactly 5 characters (valid edge case)
-      'abcdefghij12345',     // exactly 15 characters (valid edge case)
+      'Abcd1',               // exactly 5 characters (valid edge case)
+      'Abcdefghij12345',     // exactly 15 characters (valid edge case)
       'theValid1',  // within the valid length range
     ])('"%s" returns a truthy response because it is within the valid length range', (password) => {
 
@@ -118,7 +118,7 @@ describe('password validator', () => {
   
     test('"password1" returns a truthy response because it contains a digit', () => {
       // arrange
-      const password = 'password1';
+      const password = 'Password1';
   
       // act
       const validationResult = PasswordValidator.Validate(password);
@@ -128,6 +128,24 @@ describe('password validator', () => {
       expect(validationResult.errors).toHaveLength(0);
     });
 
+  });
+
+  describe('Password must contain at least one uppercase letter', () => {
+
+    test('"lowercaseonly" returns a false-y response because it lacks an uppercase letter', () => {
+      // arrange
+      const password = 'lowercaseonly1'; // No uppercase letters
+  
+      // act
+      const validationResult = PasswordValidator.Validate(password);
+  
+      // assert
+      expect(validationResult.result).toBe(false);
+      expect(validationResult.errors).toHaveLength(1);
+      expect(validationResult.errors[0].type).toBe('NoUpperCaseCharacterError');
+      expect(validationResult.errors[0].message).toBe('Password must contain at least one upper case letter.');
+    });
+  
   });
 })
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -96,6 +96,18 @@ describe('password validator', () => {
     expect(validationResult.errors[0].type).toBe('InvalidLengthError');
     expect(validationResult.errors[0].message).toBe('Password must be between 5 and 15 characters long.');
   });
+
+  test('"theValid1" returns a truthy response because it is within the valid length range', () => {
+    // arrange
+    const password = 'theValid1'; // 9 characters, valid
+
+    // act
+    const validationResult = PasswordValidator.Validate(password);
+
+    // assert
+    expect(validationResult.result).toBe(true);
+    expect(validationResult.errors).toHaveLength(0); // No errors expected
+  });
 })
 
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -118,16 +118,16 @@ describe('password validator', () => {
   
     test('"password1" returns a truthy response because it contains a digit', () => {
       // arrange
-      const password = 'password1'; // Contains the digit '1'
+      const password = 'password1';
   
       // act
       const validationResult = PasswordValidator.Validate(password);
   
       // assert
       expect(validationResult.result).toBe(true);
-      expect(validationResult.errors).toHaveLength(0); // No errors expected
+      expect(validationResult.errors).toHaveLength(0);
     });
-    
+
   });
 })
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -1,15 +1,19 @@
-import { PasswordValidator } from ".";
+import { PasswordValidator, ValidationResult } from ".";
 
+// Utility function for asserting successful validation
+function expectToPass(validationResult: ValidationResult) {
+    expect(validationResult.result).toBe(true);
+    expect(validationResult.errors).toHaveLength(0);
+}
 
 describe('password validator', () => {
 
   it('Should list all the occurring validation errors', () => {
     // arrange
-    const pasword = '';
+    const password = '';
 
     // act
-
-    const validationResult = PasswordValidator.Validate(pasword);
+    const validationResult = PasswordValidator.Validate(password);
 
     // assert
     expect(validationResult.result).toBe(false);
@@ -20,17 +24,16 @@ describe('password validator', () => {
     expect(validationResult.errors[1].message).toBe('Password must contain at least one digit.');
     expect(validationResult.errors[2].type).toBe('NoUpperCaseCharacterError');
     expect(validationResult.errors[2].message).toBe('Password must contain at least one upper case letter.');
-  })
+  });
 
-  describe('The password must be between 5 and 15 characters long', ()=>{
+  describe('The password must be between 5 and 15 characters long', () => {
 
     // Parameterized tests for invalid length cases
     test.each([
       'thePhysical1234567',  // exceeds 15 characters
-      'Abc1',                 // exactly 4 characters (pne below the limit)
+      'Abc1',                 // exactly 4 characters (one below the limit)
       'Abcdefghijklmno1'     // exactly 16 characters (one over the limit)
     ])('"%s" returns a false-y response due to invalid length', (password) => {
-
       // act
       const validationResult = PasswordValidator.Validate(password);
 
@@ -41,19 +44,17 @@ describe('password validator', () => {
       expect(validationResult.errors[0].message).toBe('Password must be between 5 and 15 characters long.');
     });
 
-    // Parameterized test for valid length case
+    // Parameterized test for valid length cases
     test.each([
       'Abcd1',               // exactly 5 characters (valid edge case)
       'Abcdefghij12345',     // exactly 15 characters (valid edge case)
       'theValid1',  // within the valid length range
     ])('"%s" returns a truthy response because it is within the valid length range', (password) => {
-
       // act
       const validationResult = PasswordValidator.Validate(password);
 
       // assert
-      expect(validationResult.result).toBe(true);
-      expect(validationResult.errors).toHaveLength(0);
+      expectToPass(validationResult);
     });
 
   });
@@ -82,8 +83,7 @@ describe('password validator', () => {
       const validationResult = PasswordValidator.Validate(password);
   
       // assert
-      expect(validationResult.result).toBe(true);
-      expect(validationResult.errors).toHaveLength(0);
+      expectToPass(validationResult);
     });
 
   });
@@ -112,11 +112,8 @@ describe('password validator', () => {
       const validationResult = PasswordValidator.Validate(password);
   
       // assert
-      expect(validationResult.result).toBe(true);
-      expect(validationResult.errors).toHaveLength(0);
+      expectToPass(validationResult);
     });
   
   });
-})
-
-
+});

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.spec.ts
@@ -15,106 +15,106 @@ function expectToFail(validationResult: ValidationResult, ...errors: ValidationE
 
 describe('password validator', () => {
 
-it('Should list all the occurring validation errors', () => {
-  // arrange
-  const password = '';
-
-  // act
-  const validationResult = PasswordValidator.Validate(password);
-
-  // assert
-  expectToFail(validationResult,
-    { type: 'InvalidLengthError', message: 'Password must be between 5 and 15 characters long.' },
-    { type: 'NoDigitError', message: 'Password must contain at least one digit.' },
-    { type: 'NoUpperCaseCharacterError', message: 'Password must contain at least one upper case letter.' }
-  );
-});
-
-describe('The password must be between 5 and 15 characters long', () => {
-
-  // Parameterized tests for invalid length cases
-  test.each([
-    'thePhysical1234567',  // exceeds 15 characters
-    'Abc1',                 // exactly 4 characters (one below the limit)
-    'Abcdefghijklmno1'     // exactly 16 characters (one over the limit)
-  ])('"%s" returns a false-y response due to invalid length', (password) => {
-    // act
-    const validationResult = PasswordValidator.Validate(password);
-
-    // assert
-    expectToFail(validationResult,
-      { type: 'InvalidLengthError', message: 'Password must be between 5 and 15 characters long.' }
-    );
-  });
-
-  // Parameterized test for valid length cases
-  test.each([
-    'Abcd1',               // exactly 5 characters (valid edge case)
-    'Abcdefghij12345',     // exactly 15 characters (valid edge case)
-    'theValid1',           // within the valid length range
-  ])('"%s" returns a truthy response because it is within the valid length range', (password) => {
-    // act
-    const validationResult = PasswordValidator.Validate(password);
-
-    // assert
-    expectToPass(validationResult);
-  });
-
-});
-
-describe('Password must contain at least one digit', () => {
-
-  test('"maxwellTheBe" returns a false-y response because it lacks a digit', () => {
+  it('Should list all the occurring validation errors', () => {
     // arrange
-    const password = 'maxwellTheBe';
+    const password = '';
 
     // act
     const validationResult = PasswordValidator.Validate(password);
 
     // assert
     expectToFail(validationResult,
-      { type: 'NoDigitError', message: 'Password must contain at least one digit.' }
-    );
-  });
-
-  test('"password1" returns a truthy response because it contains a digit', () => {
-    // arrange
-    const password = 'Password1';
-
-    // act
-    const validationResult = PasswordValidator.Validate(password);
-
-    // assert
-    expectToPass(validationResult);
-  });
-
-});
-
-describe('Password must contain at least one uppercase letter', () => {
-
-  test('"maxwell1_c" returns a false-y response because it lacks an uppercase letter', () => {
-    // arrange
-    const password = 'maxwell1_c';
-
-    // act
-    const validationResult = PasswordValidator.Validate(password);
-
-    // assert
-    expectToFail(validationResult,
+      { type: 'InvalidLengthError', message: 'Password must be between 5 and 15 characters long.' },
+      { type: 'NoDigitError', message: 'Password must contain at least one digit.' },
       { type: 'NoUpperCaseCharacterError', message: 'Password must contain at least one upper case letter.' }
     );
   });
-  
-  test('"Password1" returns a truthy response because it contains an uppercase letter', () => {
-    // arrange
-    const password = 'Password1';
 
-    // act
-    const validationResult = PasswordValidator.Validate(password);
+  describe('The password must be between 5 and 15 characters long', () => {
 
-    // assert
-    expectToPass(validationResult);
+    // Parameterized tests for invalid length cases
+    test.each([
+      'thePhysical1234567',  // exceeds 15 characters
+      'Abc1',                 // exactly 4 characters (one below the limit)
+      'Abcdefghijklmno1'     // exactly 16 characters (one over the limit)
+    ])('"%s" returns a false-y response due to invalid length', (password) => {
+      // act
+      const validationResult = PasswordValidator.Validate(password);
+
+      // assert
+      expectToFail(validationResult,
+        { type: 'InvalidLengthError', message: 'Password must be between 5 and 15 characters long.' }
+      );
+    });
+
+    // Parameterized test for valid length cases
+    test.each([
+      'Abcd1',               // exactly 5 characters (valid edge case)
+      'Abcdefghij12345',     // exactly 15 characters (valid edge case)
+      'theValid1',           // within the valid length range
+    ])('"%s" returns a truthy response because it is within the valid length range', (password) => {
+      // act
+      const validationResult = PasswordValidator.Validate(password);
+
+      // assert
+      expectToPass(validationResult);
+    });
+
   });
 
-});
+  describe('Password must contain at least one digit', () => {
+
+    test('"maxwellTheBe" returns a false-y response because it lacks a digit', () => {
+      // arrange
+      const password = 'maxwellTheBe';
+
+      // act
+      const validationResult = PasswordValidator.Validate(password);
+
+      // assert
+      expectToFail(validationResult,
+        { type: 'NoDigitError', message: 'Password must contain at least one digit.' }
+      );
+    });
+
+    test('"password1" returns a truthy response because it contains a digit', () => {
+      // arrange
+      const password = 'Password1';
+
+      // act
+      const validationResult = PasswordValidator.Validate(password);
+
+      // assert
+      expectToPass(validationResult);
+    });
+
+  });
+
+  describe('Password must contain at least one uppercase letter', () => {
+
+    test('"maxwell1_c" returns a false-y response because it lacks an uppercase letter', () => {
+      // arrange
+      const password = 'maxwell1_c';
+
+      // act
+      const validationResult = PasswordValidator.Validate(password);
+
+      // assert
+      expectToFail(validationResult,
+        { type: 'NoUpperCaseCharacterError', message: 'Password must contain at least one upper case letter.' }
+      );
+    });
+    
+    test('"Password1" returns a truthy response because it contains an uppercase letter', () => {
+      // arrange
+      const password = 'Password1';
+
+      // act
+      const validationResult = PasswordValidator.Validate(password);
+
+      // assert
+      expectToPass(validationResult);
+    });
+
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
@@ -1,6 +1,16 @@
+type ValidationError = {
+    type: string;
+    message: string;
+};
+
+type ValidationResult = {
+    result: boolean;
+    errors: ValidationError[];
+};
+
 export class PasswordValidator {
-    static Validate(password: string) {
-        const errors: { type: string; message: string }[] = [];
+    static Validate(password: string): ValidationResult {
+        const errors: ValidationError[] = [];
 
         // Validate length
         if (password.length < 5 || password.length > 15) {

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
@@ -5,78 +5,66 @@ export type ValidationError = {
 
 export type ValidationResult = {
     result: boolean;
-    errors: ValidationError[];
+    errors: ReadonlyArray<ValidationError>;
 };
+
+class ValidationResultImpl implements ValidationResult {
+    readonly result: boolean;
+    readonly errors: ReadonlyArray<ValidationError>;
+
+    constructor(result: boolean, errors: ValidationError[] = []) {
+        this.result = result;
+        this.errors = errors;
+    }
+
+    combine(other: ValidationResultImpl): ValidationResultImpl {
+        const combinedErrors = [...this.errors, ...other.errors];
+        const allPass = this.result && other.result;
+
+        return new ValidationResultImpl(allPass, combinedErrors);
+    }
+}
 
 export class PasswordValidator {
     static Validate(password: string): ValidationResult {
-        
-        const lengthValidation = this.ValidateLength(password);
-        const digitValidation = this.ValidateDigit(password);
-        const upperCaseValidation = this.ValidateUpperCase(password);
-
-        return this.CombineResults(lengthValidation, digitValidation, upperCaseValidation);
+        return this.ValidateLength(password).
+        combine(this.ValidateDigit(password)).
+        combine(this.ValidateUpperCase(password));
     }
 
-    private static ValidateLength(password: string): ValidationResult {
+    private static ValidateLength(password: string): ValidationResultImpl {
         if (password.length < 5 || password.length > 15) {
-            return {
-                result: false,
-                errors: [
-                    {
-                        type: 'InvalidLengthError',
-                        message: 'Password must be between 5 and 15 characters long.'
-                    }
-                ]
-            };
+            return new ValidationResultImpl(false, [
+                {
+                    type: 'InvalidLengthError',
+                    message: 'Password must be between 5 and 15 characters long.'
+                }
+            ]);
         }
-        return { result: true, errors: [] };
+        return new ValidationResultImpl(true);
     }
 
-    private static ValidateDigit(password: string): ValidationResult {
+    private static ValidateDigit(password: string): ValidationResultImpl {
         if (!/\d/.test(password)) {
-            return {
-                result: false,
-                errors: [
-                    {
-                        type: 'NoDigitError',
-                        message: 'Password must contain at least one digit.'
-                    }
-                ]
-            };
+            return new ValidationResultImpl(false, [
+                {
+                    type: 'NoDigitError',
+                    message: 'Password must contain at least one digit.'
+                }
+            ]);
         }
-        return { result: true, errors: [] };
+        return new ValidationResultImpl(true);
     }
 
-    private static ValidateUpperCase(password: string): ValidationResult {
+    private static ValidateUpperCase(password: string): ValidationResultImpl {
         if (!/[A-Z]/.test(password)) {
-            return {
-                result: false,
-                errors: [
-                    {
-                        type: 'NoUpperCaseCharacterError',
-                        message: 'Password must contain at least one upper case letter.'
-                    }
-                ]
-            };
+            return new ValidationResultImpl(false, [
+                {
+                    type: 'NoUpperCaseCharacterError',
+                    message: 'Password must contain at least one upper case letter.'
+                }
+            ]);
         }
-        return { result: true, errors: [] };
-    }
-
-    private static CombineResults(...results: ValidationResult[]): ValidationResult {
-        const combinedErrors: ValidationError[] = [];
-        let allPass = true;
-
-        for (const result of results) {
-            if (!result.result) {
-                allPass = false;
-                combinedErrors.push(...result.errors);
-            }
-        }
-
-        return {
-            result: allPass,
-            errors: combinedErrors
-        };
+        return new ValidationResultImpl(true);
     }
 }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
@@ -29,6 +29,15 @@ export class PasswordValidator {
             });
         }
 
+         // Validate presence of at least one uppercase letter
+         const hasUpperCase = /[A-Z]/.test(password);
+         if (!hasUpperCase) {
+             errors.push({
+                 type: 'NoUpperCaseCharacterError',
+                 message: 'Password must contain at least one upper case letter.'
+             });
+         } 
+
         // Result based on whether any errors were found
         const result = errors.length === 0;
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
@@ -1,0 +1,13 @@
+export class PasswordValidator {
+    static Validate(password: string) {
+        return {
+            result: false,
+            errors: [
+                {
+                    type: 'InvalidLengthError', 
+                    message: 'Password must be between 5 and 15 characters long.'
+                }
+            ]
+        }
+    }
+}

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
@@ -10,40 +10,73 @@ export type ValidationResult = {
 
 export class PasswordValidator {
     static Validate(password: string): ValidationResult {
-        const errors: ValidationError[] = [];
+        
+        const lengthValidation = this.ValidateLength(password);
+        const digitValidation = this.ValidateDigit(password);
+        const upperCaseValidation = this.ValidateUpperCase(password);
 
-        // Validate length
+        return this.CombineResults(lengthValidation, digitValidation, upperCaseValidation);
+    }
+
+    private static ValidateLength(password: string): ValidationResult {
         if (password.length < 5 || password.length > 15) {
-            errors.push({
-                type: 'InvalidLengthError',
-                message: 'Password must be between 5 and 15 characters long.'
-            });
+            return {
+                result: false,
+                errors: [
+                    {
+                        type: 'InvalidLengthError',
+                        message: 'Password must be between 5 and 15 characters long.'
+                    }
+                ]
+            };
         }
+        return { result: true, errors: [] };
+    }
 
-        // Validate presence of at least one digit
-        const hasDigit = /\d/.test(password);
-        if (!hasDigit) {
-            errors.push({
-                type: 'NoDigitError',
-                message: 'Password must contain at least one digit.'
-            });
+    private static ValidateDigit(password: string): ValidationResult {
+        if (!/\d/.test(password)) {
+            return {
+                result: false,
+                errors: [
+                    {
+                        type: 'NoDigitError',
+                        message: 'Password must contain at least one digit.'
+                    }
+                ]
+            };
         }
+        return { result: true, errors: [] };
+    }
 
-         // Validate presence of at least one uppercase letter
-         const hasUpperCase = /[A-Z]/.test(password);
-         if (!hasUpperCase) {
-             errors.push({
-                 type: 'NoUpperCaseCharacterError',
-                 message: 'Password must contain at least one upper case letter.'
-             });
-         } 
+    private static ValidateUpperCase(password: string): ValidationResult {
+        if (!/[A-Z]/.test(password)) {
+            return {
+                result: false,
+                errors: [
+                    {
+                        type: 'NoUpperCaseCharacterError',
+                        message: 'Password must contain at least one upper case letter.'
+                    }
+                ]
+            };
+        }
+        return { result: true, errors: [] };
+    }
 
-        // Result based on whether any errors were found
-        const result = errors.length === 0;
+    private static CombineResults(...results: ValidationResult[]): ValidationResult {
+        const combinedErrors: ValidationError[] = [];
+        let allPass = true;
+
+        for (const result of results) {
+            if (!result.result) {
+                allPass = false;
+                combinedErrors.push(...result.errors);
+            }
+        }
 
         return {
-            result,
-            errors
+            result: allPass,
+            errors: combinedErrors
         };
     }
 }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
@@ -18,16 +18,19 @@ class ValidationResultImpl implements ValidationResult {
     readonly result: boolean;
     readonly errors: ReadonlyArray<ValidationError>;
 
+    constructor(result: true);
+    constructor(result: false, errors: ValidationError[]);
     constructor(result: boolean, errors: ValidationError[] = []) {
         this.result = result;
         this.errors = errors;
     }
 
     combine(other: ValidationResultImpl): ValidationResultImpl {
-        const combinedErrors = [...this.errors, ...other.errors];
-        const allPass = this.result && other.result;
+        if(this.result && other.result){
+            return new ValidationResultImpl(true);
+        }
 
-        return new ValidationResultImpl(allPass, combinedErrors);
+        return new ValidationResultImpl(false, [...this.errors, ...other.errors]);
     }
 }
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
@@ -3,7 +3,7 @@ type ValidationError = {
     message: string;
 };
 
-type ValidationResult = {
+export type ValidationResult = {
     result: boolean;
     errors: ValidationError[];
 };

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
@@ -1,27 +1,30 @@
 export class PasswordValidator {
     static Validate(password: string) {
-      const errors = [];
-  
-      // Check if password length is valid
-      if (password.length < 5 || password.length > 15) {
-        errors.push({
-          type: 'InvalidLengthError',
-          message: 'Password must be between 5 and 15 characters long.'
-        });
-      }
-  
-      // If there are no errors, return a valid response
-      if (errors.length === 0) {
+        const errors: { type: string; message: string }[] = [];
+
+        // Validate length
+        if (password.length < 5 || password.length > 15) {
+            errors.push({
+                type: 'InvalidLengthError',
+                message: 'Password must be between 5 and 15 characters long.'
+            });
+        }
+
+        // Validate presence of at least one digit
+        const hasDigit = /\d/.test(password);
+        if (!hasDigit) {
+            errors.push({
+                type: 'NoDigitError',
+                message: 'Password must contain at least one digit.'
+            });
+        }
+
+        // Result based on whether any errors were found
+        const result = errors.length === 0;
+
         return {
-          result: true,
-          errors: []
+            result,
+            errors
         };
-      }
-  
-      // Otherwise, return the errors
-      return {
-        result: false,
-        errors: errors
-      };
     }
-  }
+}

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
@@ -1,4 +1,4 @@
-type ValidationError = {
+export type ValidationError = {
     type: string;
     message: string;
 };

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
@@ -1,13 +1,27 @@
 export class PasswordValidator {
     static Validate(password: string) {
+      const errors = [];
+  
+      // Check if password length is valid
+      if (password.length < 5 || password.length > 15) {
+        errors.push({
+          type: 'InvalidLengthError',
+          message: 'Password must be between 5 and 15 characters long.'
+        });
+      }
+  
+      // If there are no errors, return a valid response
+      if (errors.length === 0) {
         return {
-            result: false,
-            errors: [
-                {
-                    type: 'InvalidLengthError', 
-                    message: 'Password must be between 5 and 15 characters long.'
-                }
-            ]
-        }
+          result: true,
+          errors: []
+        };
+      }
+  
+      // Otherwise, return the errors
+      return {
+        result: false,
+        errors: errors
+      };
     }
-}
+  }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/src/index.ts
@@ -1,5 +1,5 @@
 export type ValidationError = {
-    type: string;
+    type: ValidationErrorType;
     message: string;
 };
 
@@ -7,6 +7,12 @@ export type ValidationResult = {
     result: boolean;
     errors: ReadonlyArray<ValidationError>;
 };
+
+export enum ValidationErrorType {
+    InvalidLengthError,
+    NoDigitError,
+    NoUpperCaseCharacterError
+}
 
 class ValidationResultImpl implements ValidationResult {
     readonly result: boolean;
@@ -36,7 +42,7 @@ export class PasswordValidator {
         if (password.length < 5 || password.length > 15) {
             return new ValidationResultImpl(false, [
                 {
-                    type: 'InvalidLengthError',
+                    type: ValidationErrorType.InvalidLengthError,
                     message: 'Password must be between 5 and 15 characters long.'
                 }
             ]);
@@ -48,7 +54,7 @@ export class PasswordValidator {
         if (!/\d/.test(password)) {
             return new ValidationResultImpl(false, [
                 {
-                    type: 'NoDigitError',
+                    type: ValidationErrorType.NoDigitError,
                     message: 'Password must contain at least one digit.'
                 }
             ]);
@@ -60,7 +66,7 @@ export class PasswordValidator {
         if (!/[A-Z]/.test(password)) {
             return new ValidationResultImpl(false, [
                 {
-                    type: 'NoUpperCaseCharacterError',
+                    type: ValidationErrorType.NoUpperCaseCharacterError,
                     message: 'Password must contain at least one upper case letter.'
                 }
             ]);

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/tsconfig.json
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/2_Arrange_Act_Assert_Backwards/2_1_Password_Validator/tsconfig.json
@@ -11,6 +11,5 @@
     "types": ["node", "jest"],
     "skipLibCheck": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["src/**/*.spec.ts"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
### Grading checklist

- [x] I have implemented the minimum requirements listed in the project description
- [x] I have Programmed By Wishful Thinking, designing the response API before it was actually created 
- [x] I have Worked Backwards, starting at the Assert, then going to the Act and the Arrange
- [x] I have tests that validate the following statements:
  - [x] "maxwell1_c" returns a false-y response because of a lack of uppercase characters
  - [x] "maxwellTheBe" returns a false-y response because of a lack of digits
  - [x] "thePhysical1234567" returns a false-y response because of exceeding the 15 character length
- [x] Once I have made the aforementioned tests pass, I have refactored my test specifications to use `it.each()` to perform parameterization if there is sufficient duplication (see Tip #3 here)
- [x] There is no duplication in my test code or my production code

### How I did it

Disclaimer: After sketching the responsibilities and the API, I used ChatGPT to go through the whole process, step-by-step. It was especially fun explaining to it what and how I want to refactor 😆 

- First I tried to discover the main Collaborators and Responsibilities https://github.com/enekesabel/the-software-essentialist/pull/3/commits/20b57a5779dc95236ae655893451301c3a006e7b
- Then I sketched up an API following Program By Wishful Thinking https://github.com/enekesabel/the-software-essentialist/pull/3/commits/5b611f34e53a2fc19507a91357c06afa4641155c
- Improved upon that API https://github.com/enekesabel/the-software-essentialist/pull/3/commits/cc3095973a10d9db76ada6f6890feb659c398c02
- Used the Triangulation technique to write the tests and implementation with TDD
    - only committed on green
    - first I drilled down on the length-matching feature and created a lot of tests. Most of them broke once I started adding the remaining features, so I also had to fix existing tests while writing a new one: https://github.com/enekesabel/the-software-essentialist/pull/3/commits/f78dff3d288a3b53d2ee821bfa9d74df75366fad
-  In the end I refactored the tests as well by extracting 2 utility methods - could have done it sooner:
    - https://github.com/enekesabel/the-software-essentialist/pull/3/commits/cda01e315486294f0aeb2705b3de0bacab44d55f
     - https://github.com/enekesabel/the-software-essentialist/pull/3/commits/15f7b4c24c278c620baed14379e299ec14380232
- went a little overboard, and satisfied my overengineering urges:
  - https://github.com/enekesabel/the-software-essentialist/pull/3/commits/c74bd6986c711ab671366c48765b272c5165fb7e
  - https://github.com/enekesabel/the-software-essentialist/pull/3/commits/01254e013c59bbc027714eeb6cc70c1975899a25